### PR TITLE
Refactor: Remove development-related and redundant comments

### DIFF
--- a/examples/play_game.py
+++ b/examples/play_game.py
@@ -1,15 +1,11 @@
 import os
 import sys
 
-# Adjust the Python path to include the 'src' directory
-# This allows finding the bracket_city_mcp package
-# Assumes 'examples' is a sibling of 'src' or this script is run from the project root
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SRC_DIR = os.path.join(PROJECT_ROOT, "src")
 if SRC_DIR not in sys.path:
     sys.path.insert(0, SRC_DIR)
 
-# Now we can import from our package
 from bracket_city_mcp.game.game import Game
 
 # Path to the game JSON files
@@ -19,7 +15,6 @@ ORIGINAL_GAME_FILE = os.path.join(PROJECT_ROOT, "games", "json", "20250110.json"
 # Use the valid game as the default for the example
 DEFAULT_GAME_FILE = VALID_TEST_GAME_FILE
 if not os.path.exists(DEFAULT_GAME_FILE):
-    # Fallback to original if valid test one somehow isn't there, though it should be
     print(f"Warning: Default valid game '{VALID_TEST_GAME_FILE}' not found. Trying original game file.")
     DEFAULT_GAME_FILE = ORIGINAL_GAME_FILE
 
@@ -30,8 +25,6 @@ def run_console_game(game_file_path: str):
     """
     if not os.path.exists(game_file_path):
         print(f"Error: Game file not found at {game_file_path}")
-        # Try to find it relative to where the script is, if in project root.
-        # This logic might be a bit redundant if PROJECT_ROOT is solid, but can be a fallback.
         alt_path = os.path.join(os.path.dirname(__file__), "..", game_file_path) # Assuming game_file_path was relative
         alt_path = os.path.normpath(alt_path)
         if os.path.exists(alt_path):
@@ -105,12 +98,8 @@ def run_console_game(game_file_path: str):
             else:
                 if selected_clue_id in game.clues and not game.clues[selected_clue_id].completed:
                      print("Incorrect answer. Try again or pick another clue.")
-                # If it was not active, the game.answer_clue would return False,
-                # but our selection logic should prevent this.
-                # If clue_id doesn't exist, game.answer_clue also returns False.
-                # No specific message needed here as answer_clue doesn't distinguish failure reasons to caller.
 
-        except ValueError: # For int(choice_str)
+        except ValueError:
             print("Invalid input. Please enter a number for the clue choice.")
         except Exception as e:
             print(f"An unexpected error occurred: {e}")

--- a/scripts/parse_game.py
+++ b/scripts/parse_game.py
@@ -21,50 +21,35 @@ def parse_bracket_city(game_string: str) -> str:
     clues = {}
     clue_counter = 1
     
-    # Use a working copy of the string that we can modify
     processing_string = game_string
 
     # Loop as long as there are opening brackets in the string
     while '[' in processing_string:
-        # Find the position of the *last* opening bracket. This ensures
-        # we are always starting with the most deeply nested clue.
         last_open_bracket_pos = processing_string.rfind('[')
         
-        # From that position, find the *first* closing bracket. This
-        # pair will define the innermost clue.
         first_close_bracket_pos = processing_string.find(']', last_open_bracket_pos)
 
         if first_close_bracket_pos == -1:
-            # Error case: Mismatched brackets. Stop processing.
             print("Error: Mismatched brackets found.")
             break
             
-        # Extract the raw clue text from between the brackets
         clue_text = processing_string[last_open_bracket_pos + 1 : first_close_bracket_pos]
         
-        # Generate the unique ID for this new clue
         clue_id = f"#C{clue_counter}#"
         
-        # Find all dependency placeholders (e.g., #C1#, #C2#) already in the clue text
-        # The re.findall will return a list like ['1', '7'], which we format.
         dependencies = sorted([f"#C{num}#" for num in re.findall(r'#C(\d+)#', clue_text)])
         
-        # Store the extracted clue information
         clues[clue_id] = {
             "clue": clue_text.strip(),
             "answer": "",
             "depends_on": dependencies
         }
         
-        # Replace the entire bracketed clue in the main string with its new ID
-        # This simplifies the string for the next iteration.
         full_clue_substring = processing_string[last_open_bracket_pos : first_close_bracket_pos + 1]
         processing_string = processing_string.replace(full_clue_substring, clue_id, 1)
         
-        # Increment the counter for the next clue
         clue_counter += 1
 
-    # Create the final JSON structure, sorting clues by their number for readability
     sorted_clue_keys = sorted(clues.keys(), key=lambda x: int(re.search(r'(\d+)', x).group(1)))
     
     sorted_clues = {key: clues[key] for key in sorted_clue_keys}
@@ -73,7 +58,6 @@ def parse_bracket_city(game_string: str) -> str:
         "clues": sorted_clues
     }
     
-    # Return the final result as a formatted JSON string
     return json.dumps(final_json_output, indent=2)
 
 def main():
@@ -81,7 +65,6 @@ def main():
     Main function to run the script from the command line.
     Handles reading from an input file and writing to an output file.
     """
-    # Set up the argument parser to handle command-line arguments
     parser = argparse.ArgumentParser(
         description="Parse a 'bracket city' puzzle from a text file and save it as JSON."
     )
@@ -96,7 +79,6 @@ def main():
     
     args = parser.parse_args()
 
-    # Read the input file with error handling
     try:
         with open(args.input_file, 'r', encoding='utf-8') as f:
             raw_game_string = f.read()
@@ -107,10 +89,8 @@ def main():
         print(f"An error occurred while reading the input file: {e}")
         return
 
-    # Parse the string and get the JSON output
     parsed_json = parse_bracket_city(raw_game_string)
 
-    # Write the output to the specified JSON file with error handling
     try:
         with open(args.output_file, 'w', encoding='utf-8') as f:
             f.write(parsed_json)

--- a/src/bracket_city_mcp/game/game.py
+++ b/src/bracket_city_mcp/game/game.py
@@ -30,11 +30,9 @@ class Game:
                     depends_on=clue_info.get("depends_on", [])
                 )
 
-        # These will be properly implemented in the next steps
         self._build_graph()
         self._perform_initial_sort()
 
-        # Check for the single end clue requirement
         if len(self.end_clues) != 1:
             raise ValueError(
                 f"Game must have exactly one end clue. "
@@ -83,8 +81,6 @@ class Game:
                     if dependency_id in self.clues: # Ensure dependency exists
                         self.adj[dependency_id].append(clue_id)
 
-            # Ensure all clues are keys in adj and rev_adj, even if they have no connections
-            # This helps in _perform_initial_sort for identifying start/end clues correctly.
             if clue_id not in self.adj:
                 self.adj[clue_id] = []
             if clue_id not in self.rev_adj:
@@ -110,7 +106,6 @@ class Game:
             if not self.adj[clue_id]:
                 self.end_clues.append(clue_id)
 
-        # Sort for deterministic behavior, though not strictly necessary for functionality
         self.start_clues.sort()
         self.end_clues.sort()
 
@@ -127,26 +122,17 @@ class Game:
             Returns False if the clue is not active or does not exist.
         """
         if clue_id not in self.clues:
-            # Or raise an error, e.g., ValueError(f"Clue ID {clue_id} not found.")
             return False
 
         if clue_id not in self.active_clues:
-            # Clue is not currently available to be answered.
-            # You might want to provide more specific feedback to the user here.
             return False
 
         clue_to_answer = self.clues[clue_id]
 
-        # The Clue object's answer_clue method handles case-insensitivity
-        # and updates its own 'completed' status.
         is_correct = clue_to_answer.answer_clue(provided_answer)
 
         if is_correct:
-            # Remove from active_clues as it's now completed.
-            # It won't be added back by _reveal_new_clues because it's completed.
             self.active_clues.discard(clue_id)
-
-            # Now, check if this completion reveals new clues.
             self._reveal_new_clues(clue_id)
 
         return is_correct
@@ -165,13 +151,12 @@ class Game:
 
         for potential_new_clue_id in self.adj[completed_clue_id]:
             if potential_new_clue_id not in self.clues:
-                continue # Should not happen if graph is built correctly
+                continue
 
             potential_clue_obj = self.clues[potential_new_clue_id]
             if potential_clue_obj.completed:
-                continue # Already completed, nothing to do
+                continue
 
-            # Check if all dependencies for this potential new clue are met
             all_dependencies_met = True
             if potential_new_clue_id in self.rev_adj:
                 for dependency_id in self.rev_adj[potential_new_clue_id]:
@@ -212,6 +197,5 @@ class Game:
         Returns:
             The rendered text of the game.
         """
-        # The __init__ method already validates that len(self.end_clues) == 1
         end_clue_id = self.end_clues[0]
         return self.get_rendered_clue_text(end_clue_id)

--- a/src/bracket_city_mcp/main.py
+++ b/src/bracket_city_mcp/main.py
@@ -1,14 +1,10 @@
-# main.py
 from mcp.server.fastmcp import FastMCP
 
-# Global counter
 counter = 0
 
-# Create an MCP server
 mcp = FastMCP("Demo")
 
 
-# Add an addition tool
 @mcp.tool()
 def add(a: int, b: int) -> int:
     """Add two numbers"""
@@ -23,7 +19,6 @@ def increment_counter() -> int:
     return counter
 
 
-# Add a dynamic greeting resource
 @mcp.resource("greeting://{name}")
 def get_greeting(name: str) -> str:
     """Get a personalized greeting"""

--- a/tests/test_clue.py
+++ b/tests/test_clue.py
@@ -1,6 +1,6 @@
-import pytest # Import pytest if needed for specific features like raises, skip, fixtures
+import pytest
 from src.bracket_city_mcp.game.clue import Clue
-from src.bracket_city_mcp.game.game import Game # Though using MockGame, good to have for context
+from src.bracket_city_mcp.game.game import Game
 
 
 # Helper MockGame class for testing Clue.get_rendered_text
@@ -61,18 +61,12 @@ def test_answer_clue_empty_actual_answer():
     assert result_correct
     assert clue.completed
 
-    # Resetting for next test part within the same function
     clue.completed = False
 
     result_incorrect = clue.answer_clue("not empty")
     assert not result_incorrect
     assert not clue.completed
 
-# It's good practice to remove the if __name__ == '__main__': block
-# as pytest handles test discovery and execution.
-
-
-# Tests for Clue.get_rendered_text()
 
 def test_get_rendered_text_completed_clue():
     c1 = Clue(clue_id="#C1#", clue_text="Text C1", answer="Ans C1", depends_on=[])
@@ -161,14 +155,11 @@ def test_get_rendered_text_diamond_dependency_c1_completed():
     assert c4.get_rendered_text(mock_game) == "End [Loves Ans C1] [Hates Ans C1]"
 
 def test_get_rendered_text_diamond_dependency_c2_completed():
-    # C2 completed means its text will be its answer.
-    # C1 must be completed for C2 to be completed.
     c1 = Clue(clue_id="#C1#", clue_text="Text C1", answer="Ans C1", depends_on=[])
     c1.completed = True
     c2 = Clue(clue_id="#C2#", clue_text="Loves #C1#", answer="Ans C2", depends_on=["#C1#"])
-    c2.completed = True # This makes C2 output "Ans C2"
+    c2.completed = True
     c3 = Clue(clue_id="#C3#", clue_text="Hates #C1#", answer="Ans C3", depends_on=["#C1#"])
-    # C3 is not completed, so it will render [Hates Ans C1]
     c4 = Clue(clue_id="#C4#", clue_text="End #C2# #C3#", answer="Ans C4", depends_on=["#C2#", "#C3#"])
     mock_game = MockGame(clues_dict={"#C1#": c1, "#C2#": c2, "#C3#": c3, "#C4#": c4})
     assert c4.get_rendered_text(mock_game) == "End Ans C2 [Hates Ans C1]"

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -7,11 +7,11 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 
 ORIGINAL_GAME_JSON_PATH_CONFIG = os.path.join(BASE_DIR, "games", "json", "20250110.json")
 if not os.path.exists(ORIGINAL_GAME_JSON_PATH_CONFIG):
-    ORIGINAL_GAME_JSON_PATH_CONFIG = os.path.join("games", "json", "20250110.json") # Fallback
+    ORIGINAL_GAME_JSON_PATH_CONFIG = os.path.join("games", "json", "20250110.json")
 
 VALID_GAME_JSON_PATH_CONFIG = os.path.join(BASE_DIR, "tests", "data", "valid_single_end_clue_game.json")
 if not os.path.exists(VALID_GAME_JSON_PATH_CONFIG):
-    VALID_GAME_JSON_PATH_CONFIG = os.path.join("tests", "data", "valid_single_end_clue_game.json") # Fallback
+    VALID_GAME_JSON_PATH_CONFIG = os.path.join("tests", "data", "valid_single_end_clue_game.json")
 
 # --- Pytest Fixtures ---
 
@@ -117,10 +117,6 @@ def test_clue_reveal_logic_to_reach_end_clue_valid_game(valid_game: Game):
     assert "#E1#" not in game.active_clues
     assert game.active_clues == set(), "No clues should be active after end clue is solved."
 
-# Remove if __name__ == '__main__': block
-
-
-# --- Tests for Game.get_rendered_clue_text() and Game.get_rendered_game_text() ---
 
 def test_get_rendered_clue_text_valid_clue():
     game_data = {
@@ -129,19 +125,14 @@ def test_get_rendered_clue_text_valid_clue():
             "#C2#": {"clue": "Text C2 uses #C1#", "answer": "Ans C2", "depends_on": ["#C1#"]}
         }
     }
-    game = Game(game_data) # #C2# is the end clue, #C1# is a start clue
+    game = Game(game_data)
 
-    # C1 is not completed
     assert game.get_rendered_clue_text("#C1#") == "Text C1"
-    # C2 renders with C1's text, bracketed
     assert game.get_rendered_clue_text("#C2#") == "Text C2 uses [Text C1]"
 
-    # Answer C1
-    assert game.answer_clue("#C1#", "Ans C1") # C1 is a start clue, so it's active
+    assert game.answer_clue("#C1#", "Ans C1")
 
-    # C1 is completed, returns answer
     assert game.get_rendered_clue_text("#C1#") == "Ans C1"
-    # C2 renders with C1's answer
     assert game.get_rendered_clue_text("#C2#") == "Text C2 uses Ans C1"
 
 def test_get_rendered_clue_text_invalid_clue():
@@ -161,7 +152,7 @@ def test_get_rendered_game_text_simple_case_uncompleted():
             "#END#": {"clue": "End clue depends on #C1#", "answer": "Game Over", "depends_on": ["#C1#"]}
         }
     }
-    game = Game(game_data) # #END# is the end clue
+    game = Game(game_data)
     assert game.get_rendered_game_text() == "End clue depends on [Text C1]"
 
 def test_get_rendered_game_text_simple_case_dependency_completed():
@@ -172,7 +163,6 @@ def test_get_rendered_game_text_simple_case_dependency_completed():
         }
     }
     game = Game(game_data)
-    # #C1# is a start clue, so it's active
     game.answer_clue("#C1#", "Ans C1")
     assert game.get_rendered_game_text() == "End clue depends on Ans C1"
 
@@ -185,7 +175,6 @@ def test_get_rendered_game_text_end_clue_completed():
     }
     game = Game(game_data)
     game.answer_clue("#C1#", "Ans C1")
-    # #END# becomes active after #C1# is answered
     game.answer_clue("#END#", "Game Over")
     assert game.get_rendered_game_text() == "Game Over"
 
@@ -196,16 +185,16 @@ def test_get_rendered_game_text_complex_dependencies():
             "#C2#": {"clue": "Text C2 uses #C1#", "answer": "Ans C2", "depends_on": ["#C1#"]},
             "#END#": {"clue": "End clue uses #C2#", "answer": "Game Over All", "depends_on": ["#C2#"]}
         }
-    } # #C1# is start, #END# is end
+    }
     game = Game(game_data)
 
     assert game.get_rendered_game_text() == "End clue uses [Text C2 uses [Text C1]]"
 
-    game.answer_clue("#C1#", "Ans C1") # #C1# is a start clue
+    game.answer_clue("#C1#", "Ans C1")
     assert game.get_rendered_game_text() == "End clue uses [Text C2 uses Ans C1]"
 
-    game.answer_clue("#C2#", "Ans C2") # #C2# becomes active after #C1#
+    game.answer_clue("#C2#", "Ans C2")
     assert game.get_rendered_game_text() == "End clue uses Ans C2"
 
-    game.answer_clue("#END#", "Game Over All") # #END# becomes active after #C2#
+    game.answer_clue("#END#", "Game Over All")
     assert game.get_rendered_game_text() == "Game Over All"


### PR DESCRIPTION
I've cleaned up the codebase by removing comments that were part of the development process, such as TODOs, step-by-step procedural narration, or redundant explanations of self-evident code.

This change aims to improve code readability by ensuring comments are focused on providing essential documentation rather than development notes.