### PR TITLE
Alright, I've addressed the issue with the `test_loading_invalid_game…

### DIFF
--- a/tests/data/invalid_multiple_end_clues_game.json
+++ b/tests/data/invalid_multiple_end_clues_game.json
@@ -1,0 +1,19 @@
+{
+  "clues": {
+    "#END1#": {
+      "clue": "This is the first end clue.",
+      "answer": "Answer1",
+      "depends_on": []
+    },
+    "#END2#": {
+      "clue": "This is the second end clue.",
+      "answer": "Answer2",
+      "depends_on": []
+    },
+    "#END3#": {
+      "clue": "This is the third end clue.",
+      "answer": "Answer3",
+      "depends_on": []
+    }
+  }
+}

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -40,9 +40,17 @@ def test_game_loading_valid_json(valid_game: Game):
     assert "#S1#" in valid_game.clues
     assert valid_game.clues["#S1#"].answer == "A1"
 
-def test_loading_invalid_game_multiple_end_clues(original_game_json_path: str):
-    with pytest.raises(ValueError, match="Game must have exactly one end clue. Found 3 end clues"):
-        Game.from_json_file(original_game_json_path)
+def test_loading_invalid_game_multiple_end_clues(): # Remove original_game_json_path fixture
+    # Construct the path to the new test file relative to this test file's directory
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    invalid_game_path = os.path.join(current_dir, "data", "invalid_multiple_end_clues_game.json")
+
+    # Ensure the new test file exists before running the test
+    if not os.path.exists(invalid_game_path):
+        pytest.fail(f"Test data file not found: {invalid_game_path}")
+
+    with pytest.raises(ValueError, match=r"Game must have exactly one end clue\. Found 3 end clues: \['#END1#', '#END2#', '#END3#'\]"):
+        Game.from_json_file(invalid_game_path)
 
 def test_loading_game_no_end_clues_raises_error():
     invalid_data_no_end_circular = {


### PR DESCRIPTION
…_multiple_end_clues` test.

It seems the test was failing because it was using 'games/json/20250110.json' as an example of a file that should cause an error due to multiple end clues. However, based on the current game logic, that particular file is actually valid and only contains a single end clue.

To fix this, I've made the following changes:
1. I created a new test data file named 'tests/data/invalid_multiple_end_clues_game.json'. This file is specifically designed to have three end clues.
2. I've updated the 'test_loading_invalid_game_multiple_end_clues' test to use this new data file instead.
3. I also adjusted the expected error message pattern in the test to accurately reflect the clues present in the new data file.

This way, the test now correctly checks the logic for detecting multiple end clues without depending on a game file that wasn't actually configured for that scenario. The original 'games/json/20250110.json' file remains untouched.