### PR TITLE
Refactor: Simplify package imports and Game class access

### DIFF
--- a/examples/play_game.py
+++ b/examples/play_game.py
@@ -1,14 +1,10 @@
 import os
 import sys
 
-PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-SRC_DIR = os.path.join(PROJECT_ROOT, "src")
-if SRC_DIR not in sys.path:
-    sys.path.insert(0, SRC_DIR)
-
-from bracket_city_mcp.game.game import Game
+from bracket_city_mcp.game import Game
 
 # Path to the game JSON files
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 VALID_TEST_GAME_FILE = os.path.join(PROJECT_ROOT, "tests", "data", "valid_single_end_clue_game.json")
 ORIGINAL_GAME_FILE = os.path.join(PROJECT_ROOT, "games", "json", "20250110.json")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,6 @@ dev = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/bracket_city_mcp/game/__init__.py
+++ b/src/bracket_city_mcp/game/__init__.py
@@ -1,0 +1,1 @@
+from .game import Game

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,6 +1,6 @@
 import pytest
 import os
-from src.bracket_city_mcp.game.game import Game
+from bracket_city_mcp.game import Game
 
 # --- Path Setup ---
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))


### PR DESCRIPTION
This commit addresses the following:

1. Configured `pyproject.toml` to recognize the `src` directory as the root for package discovery. This allows you to import the main package as `bracket_city_mcp` instead of `src.bracket_city_mcp` when the package is installed.
   - Added `[tool.setuptools.packages.find]` with `where = ["src"]`.

2. Simplified the import of the `Game` class.
   - Added `from .game import Game` to `src/bracket_city_mcp/game/__init__.py`.
   - This allows `from bracket_city_mcp.game import Game` instead of `from bracket_city_mcp.game.game import Game`.

3. Updated import statements in example and test files to use the new, cleaner paths.
   - `examples/play_game.py` now uses `from bracket_city_mcp.game import Game` and has the `sys.path` manipulation for `SRC_DIR` removed.
   - `tests/test_game.py` now uses `from bracket_city_mcp.game import Game`.

All existing tests pass with these changes, and the example script runs correctly, confirming the desired import behavior has been achieved while retaining the `src` directory structure.