### PR TITLE
Refactor: Load game data from URL with date validation

### DIFF
--- a/src/bracket_city_mcp/puzzle_loader.py
+++ b/src/bracket_city_mcp/puzzle_loader.py
@@ -1,190 +1,52 @@
 import sys
 import json
-import re
 import requests
-from bs4 import BeautifulSoup
-
-def generate_puzzle_structure(html_content: str) -> dict:
-    """
-    Parses the HTML of a Bracket City puzzle page to extract the full nested
-    clue structure by recursively parsing the raw puzzle string.
-
-    Args:
-        html_content (str): The full HTML content of the puzzle page.
-
-    Returns:
-        dict: A dictionary containing the fully structured puzzle data.
-    """
-    soup = BeautifulSoup(html_content, 'lxml')
-
-    # --- Step 1: Create a master map of all clues and their answers ---
-    answers_list_ul = soup.find('ul', id='answers-list')
-    if not answers_list_ul:
-        return {"error": "Could not find the 'answers-list' <ul> element."}
-
-    clue_text_to_answer = {}
-    for li in answers_list_ul.find_all('li'):
-        clue_h2 = li.find('h2')
-        answer_span = li.find('span', class_='clue-text-answer')
-        if clue_h2 and answer_span:
-            clue_text = clue_h2.get_text(strip=True)
-            answer_text = answer_span.get_text(strip=True)
-            clue_text_to_answer[clue_text] = answer_text
-    
-    if not clue_text_to_answer:
-        return {"error": "No clues found in the answers list."}
-        
-    # --- Step 2: Extract the raw puzzle string and the final solution text ---
-    interactive_div = soup.find('div', class_='html-answers-interactive')
-    if not interactive_div:
-        return {"error": "Could not find the 'html-answers-interactive' <div> element."}
-    
-    puzzle_string = interactive_div.get_text()
-    # Normalize all whitespace (including newlines and tabs) into single spaces
-    puzzle_string = re.sub(r'\s+', ' ', puzzle_string).strip()
-
-    final_solution_text = ""
-    # Find the H1 header for the final solution section
-    solution_h1 = soup.find('h1', string=re.compile(r"Today's \[BRACKET CITY\] Final Solution"))
-    
-    # Search within the H1's parent container for the answer
-    if solution_h1 and solution_h1.parent:
-        # Search within this container for a 'strong' tag, which holds the answer text.
-        solution_strong_tag = solution_h1.parent.find('strong')
-        if solution_strong_tag:
-             final_solution_text = solution_strong_tag.get_text(strip=True)
-             # Strip the date prefix (e.g., "June 1, 1974: ") if it exists
-             final_solution_text = re.sub(r'^(\w+\s\d+,\s\d{4}:\s)', '', final_solution_text).strip()
-
-    if not final_solution_text:
-         # Use sys.stderr for warnings if this function is ever used in a context where stdout is for data
-         print("Warning: Could not find the final solution text.", file=sys.stderr)
-
-
-    # --- Step 3: Recursively parse the string to build the structure ---
-    final_clues = {}
-    # clue_id_counter = 1 # This was unused, can be removed
-
-    sorted_clues = sorted(clue_text_to_answer.keys(), key=len, reverse=True)
-    clue_text_to_id = {text: f"CLUE-C{i+1}" for i, text in enumerate(sorted_clues)}
-    
-    innermost_bracket_regex = re.compile(r'\[([^\[\]]+)\]')
-
-    processing_string = puzzle_string
-    while '[' in processing_string:
-        match = innermost_bracket_regex.search(processing_string)
-        if not match:
-            # Use sys.stderr for warnings
-            print("Warning: Could not find innermost bracket. The puzzle string may be malformed or fully processed.", file=sys.stderr)
-            break
-
-        inner_content = match.group(1).strip()
-        
-        found_clue_text = None
-        
-        # Create a regex from the inner_content by replacing all found CLUE-IDs with a wildcard.
-        temp_inner_content = re.sub(r'CLUE-C\d+', "%%PLACEHOLDER%%", inner_content)
-        escaped_content = re.escape(temp_inner_content)
-        regex_pattern_str = escaped_content.replace("%%PLACEHOLDER%%", '.*?')
-        regex_pattern = f"^{regex_pattern_str}$"
-
-        for known_clue in sorted_clues:
-            if re.match(regex_pattern, known_clue):
-                found_clue_text = known_clue
-                break
-        
-        if found_clue_text:
-            clue_id = clue_text_to_id[found_clue_text]
-            found_ids = re.findall(r'CLUE-C\d+', inner_content)
-            
-            final_clues[clue_id] = {
-                "clue": inner_content,
-                "depends_on": sorted(list(set(found_ids))),
-                "answer": clue_text_to_answer[found_clue_text]
-            }
-            processing_string = processing_string.replace(f'[{match.group(1)}]', clue_id, 1)
-        else:
-            # Use sys.stderr for warnings
-            print(f"Warning: Could not find a matching clue for content: '{inner_content}'", file=sys.stderr)
-            processing_string = processing_string.replace(f'[{match.group(1)}]', inner_content, 1)
-
-    # --- Step 4: Create the final root clue ---
-    root_clue_text = processing_string
-    root_dependencies = re.findall(r'CLUE-C\d+', root_clue_text)
-    
-    final_clues["CLUE-ROOT"] = {
-        "clue": root_clue_text,
-        "depends_on": sorted(list(set(root_dependencies))),
-        "answer": final_solution_text
-    }
-
-    return {"clues": final_clues}
-
-
-def parse_game_from_url(url: str) -> dict:
-    """
-    Fetches HTML content from a URL and parses it to extract puzzle structure.
-
-    Args:
-        url (str): The URL of the puzzle page.
-
-    Returns:
-        dict: A dictionary containing the fully structured puzzle data,
-              or an error dictionary if fetching/parsing fails.
-    """
-    try:
-        response = requests.get(url, timeout=10)  # Added timeout for robustness
-        response.raise_for_status()  # Raises an HTTPError for bad responses (4XX or 5XX)
-        html_content = response.text
-        return generate_puzzle_structure(html_content)
-    except requests.exceptions.RequestException as e:
-        # Log to stderr or use proper logging if available
-        print(f"Error fetching URL {url}: {e}", file=sys.stderr)
-        return {"error": f"Failed to fetch HTML from URL: {url}. Error: {e}"}
-    except Exception as e: # Catch any other unexpected errors during parsing
-        print(f"Unexpected error processing URL {url}: {e}", file=sys.stderr)
-        return {"error": f"An unexpected error occurred while processing URL {url}: {e}"}
 
 # Note: The main() function and if __name__ == '__main__' block from
 # scripts/parse_game_html.py are intentionally omitted as this is now a module.
 
+from datetime import datetime
 
 def load_game_data_by_date(date_str: str) -> dict:
     """
-    Loads game data for a given date, trying a local JSON file first,
-    then falling back to fetching from a URL.
+    Loads game data for a given date from a specific JSON file URL.
+    Validates the date format and range.
 
     Args:
         date_str (str): The date of the puzzle in "YYYY-MM-DD" format.
 
     Returns:
         dict: A dictionary containing the puzzle data, or an error dictionary
-              if loading/fetching/parsing fails.
+              if loading/fetching/parsing fails or date is invalid.
     """
-    file_date_str = date_str.replace("-", "")
-    filepath = f"games/json/{file_date_str}.json"
+    try:
+        # Validate date format
+        parsed_date = datetime.strptime(date_str, "%Y-%m-%d")
+    except ValueError:
+        return {"error": "Invalid date format. Expected YYYY-MM-DD."}
+
+    # Define valid date range
+    min_date = datetime(2025, 1, 1)
+    max_date = datetime(2025, 6, 16)
+
+    if not (min_date <= parsed_date <= max_date):
+        return {"error": "Date is outside the valid range (2025-01-01 to 2025-06-16)."}
+
+    # Construct the new URL
+    url = f"https://raw.githubusercontent.com/aplassard/bracket-city-mcp/refs/heads/add-game-history/games/json/{date_str}.json"
 
     try:
-        # Attempt to load from local JSON file first
-        with open(filepath, 'r', encoding='utf-8') as f:
-            game_data = json.load(f)
-        # Optional: print a message if loaded from file
-        # print(f"Loaded game data for {date_str} from local file: {filepath}", file=sys.stderr)
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()  # Raises an HTTPError for bad responses (4XX or 5XX)
+        game_data = response.json()
         return game_data
-    except FileNotFoundError:
-        # File not found, fall back to fetching from URL
-        # print(f"Local file {filepath} not found for date {date_str}. Attempting to fetch from URL.", file=sys.stderr)
-        # The date_str for parse_game_from_url needs to be in YYYY-MM-DD,
-        # which is the format of our input date_str.
-        # It internally constructs the full URL.
-        url = f"https://ladypuzzle.pro/bracket-city-hints-answers-solution/{date_str}"
-        return parse_game_from_url(url)
+    except requests.exceptions.RequestException as e:
+        # Log to stderr or use proper logging if available
+        print(f"Error fetching game data from {url}: {e}", file=sys.stderr)
+        return {"error": f"Failed to fetch game data from URL: {url}. Error: {e}"}
     except json.JSONDecodeError as e:
-        print(f"Error decoding JSON from {filepath} for date {date_str}: {e}", file=sys.stderr)
-        return {"error": f"Error decoding JSON from {filepath}: {e}"}
-    except IOError as e:
-        print(f"IOError reading file {filepath} for date {date_str}: {e}", file=sys.stderr)
-        return {"error": f"IOError reading file {filepath}: {e}"}
-    except Exception as e: # Catch any other unexpected errors during file operations
-        print(f"An unexpected error occurred with file {filepath} for date {date_str}: {e}", file=sys.stderr)
-        return {"error": f"An unexpected error occurred while trying to load from file {filepath}: {e}"}
+        print(f"Error decoding JSON from {url}: {e}", file=sys.stderr)
+        return {"error": f"Error decoding JSON from {url}: {e}"}
+    except Exception as e: # Catch any other unexpected errors
+        print(f"An unexpected error occurred while loading game data for {date_str}: {e}", file=sys.stderr)
+        return {"error": f"An unexpected error occurred while loading game data for {date_str}: {e}"}

--- a/tests/test_puzzle_loader.py
+++ b/tests/test_puzzle_loader.py
@@ -20,202 +20,105 @@ except ImportError:
 
 
 # Functions to test from the puzzle_loader module
-from bracket_city_mcp.puzzle_loader import (
-    generate_puzzle_structure,
-    parse_game_from_url,
-    load_game_data_by_date
-)
-
-# Basic HTML structure for testing generate_puzzle_structure
-BASIC_HTML_TEMPLATE = """
-<!DOCTYPE html><html><head><title>Test</title></head><body>
-{answers_list}
-{interactive_div}
-{solution_h1}
-</body></html>
-"""
-
-ANSWERS_LIST_VALID = """
-<ul id="answers-list">
-    <li><h2>CLUE-A The First Clue</h2><span class="clue-text-answer">AnswerA</span></li>
-    <li><h2>CLUE-B Another Clue</h2><span class="clue-text-answer">AnswerB</span></li>
-</ul>
-"""
-INTERACTIVE_DIV_VALID = "<div class='html-answers-interactive'>[CLUE-A The First Clue] then [CLUE-B Another Clue]</div>"
-SOLUTION_H1_VALID = "<h1>Today's [BRACKET CITY] Final Solution June 1, 1974: FinalAnswer</h1><strong>FinalAnswer</strong>"
-
-VALID_PUZZLE_HTML = BASIC_HTML_TEMPLATE.format(
-    answers_list=ANSWERS_LIST_VALID,
-    interactive_div=INTERACTIVE_DIV_VALID,
-    solution_h1=SOLUTION_H1_VALID
-)
-
-class TestGeneratePuzzleStructure(unittest.TestCase):
-    def test_gps_success(self):
-        data = generate_puzzle_structure(VALID_PUZZLE_HTML)
-        self.assertNotIn("error", data)
-        self.assertIn("clues", data)
-        self.assertIn("CLUE-C1", data["clues"]) # CLUE-A The First Clue
-        self.assertEqual(data["clues"]["CLUE-C1"]["answer"], "AnswerA")
-        self.assertIn("CLUE-C2", data["clues"]) # CLUE-B Another Clue
-        self.assertEqual(data["clues"]["CLUE-C2"]["answer"], "AnswerB")
-        self.assertIn("CLUE-ROOT", data["clues"])
-        self.assertEqual(data["clues"]["CLUE-ROOT"]["answer"], "FinalAnswer")
-        # Depends on will be sorted
-        self.assertEqual(data["clues"]["CLUE-ROOT"]["depends_on"], ["CLUE-C1", "CLUE-C2"])
-        self.assertEqual(data["clues"]["CLUE-ROOT"]["clue"], "[CLUE-C1] then [CLUE-C2]")
-
-
-    def test_gps_missing_answers_list(self):
-        html_content = BASIC_HTML_TEMPLATE.format(answers_list="", interactive_div=INTERACTIVE_DIV_VALID, solution_h1=SOLUTION_H1_VALID)
-        data = generate_puzzle_structure(html_content)
-        self.assertIn("error", data)
-        self.assertEqual(data["error"], "Could not find the 'answers-list' <ul> element.")
-
-    def test_gps_missing_interactive_div(self):
-        html_content = BASIC_HTML_TEMPLATE.format(answers_list=ANSWERS_LIST_VALID, interactive_div="", solution_h1=SOLUTION_H1_VALID)
-        data = generate_puzzle_structure(html_content)
-        self.assertIn("error", data)
-        self.assertEqual(data["error"], "Could not find the 'html-answers-interactive' <div> element.")
-
-    def test_gps_no_clues_in_answers_list(self):
-        html_content = BASIC_HTML_TEMPLATE.format(answers_list="<ul id='answers-list'></ul>", interactive_div=INTERACTIVE_DIV_VALID, solution_h1=SOLUTION_H1_VALID)
-        data = generate_puzzle_structure(html_content)
-        self.assertIn("error", data)
-        self.assertEqual(data["error"], "No clues found in the answers list.")
-
-class TestParseGameFromUrl(unittest.TestCase):
-    @patch('bracket_city_mcp.puzzle_loader.generate_puzzle_structure')
-    @patch('bracket_city_mcp.puzzle_loader.requests.get')
-    def test_pgfu_success(self, mock_requests_get, mock_gps):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.text = "<html>mock html</html>"
-        mock_response.raise_for_status = MagicMock()
-        mock_requests_get.return_value = mock_response
-
-        expected_data = {"clues": {"test": "data"}}
-        mock_gps.return_value = expected_data
-
-        result = parse_game_from_url("http://testurl.com/puzzle")
-
-        mock_requests_get.assert_called_once_with("http://testurl.com/puzzle", timeout=10)
-        mock_response.raise_for_status.assert_called_once()
-        mock_gps.assert_called_once_with("<html>mock html</html>")
-        self.assertEqual(result, expected_data)
-
-    @patch('bracket_city_mcp.puzzle_loader.requests.get')
-    def test_pgfu_requests_exception(self, mock_requests_get):
-        mock_requests_get.side_effect = requests.exceptions.RequestException("Network fail")
-        result = parse_game_from_url("http://testurl.com/puzzle")
-        self.assertIn("error", result)
-        self.assertIn("Failed to fetch HTML from URL", result["error"])
-        self.assertIn("Network fail", result["error"])
-
-    @patch('bracket_city_mcp.puzzle_loader.requests.get')
-    def test_pgfu_http_error_status(self, mock_requests_get):
-        mock_response = MagicMock()
-        mock_response.status_code = 404
-        mock_response.raise_for_status = MagicMock(side_effect=requests.exceptions.HTTPError("404 Not Found"))
-        mock_requests_get.return_value = mock_response
-
-        result = parse_game_from_url("http://testurl.com/404puzzle")
-        self.assertIn("error", result)
-        self.assertIn("Failed to fetch HTML from URL", result["error"])
-        self.assertIn("404 Not Found", result["error"])
-        mock_response.raise_for_status.assert_called_once()
-
-    @patch('bracket_city_mcp.puzzle_loader.generate_puzzle_structure')
-    @patch('bracket_city_mcp.puzzle_loader.requests.get')
-    def test_pgfu_gps_returns_error(self, mock_requests_get, mock_gps):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.text = "<html>good html</html>"
-        mock_response.raise_for_status = MagicMock()
-        mock_requests_get.return_value = mock_response
-
-        mock_gps.return_value = {"error": "gps processing failed"}
-
-        result = parse_game_from_url("http://testurl.com/goodhtmlbadparse")
-        self.assertEqual(result, {"error": "gps processing failed"})
-        mock_gps.assert_called_once_with("<html>good html</html>")
-
+from bracket_city_mcp.puzzle_loader import load_game_data_by_date
+from datetime import datetime # Used for direct datetime object creation in tests if needed
 
 class TestLoadGameDataByDate(unittest.TestCase):
-    MOCK_JSON_DATA = {"clues": {"CLUE-FILE": {"clue": "From File", "answer": "FileAns"}}}
-    MOCK_URL_DATA = {"clues": {"CLUE-URL": {"clue": "From URL", "answer": "UrlAns"}}}
+    MOCK_SUCCESS_DATA = {"game": "data", "day": "Tuesday"}
 
-    @patch('bracket_city_mcp.puzzle_loader.parse_game_from_url')
-    @patch('bracket_city_mcp.puzzle_loader.json.load')
-    @patch('builtins.open', new_callable=mock_open)
-    def test_lgdbd_loads_from_file_success(self, mock_file_open, mock_json_load, mock_pgfu):
-        mock_json_load.return_value = self.MOCK_JSON_DATA
-        date_str = "2023-01-15"
-        expected_filepath = "games/json/20230115.json"
+    @patch('bracket_city_mcp.puzzle_loader.requests.get')
+    def test_load_success_from_url(self, mock_requests_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = self.MOCK_SUCCESS_DATA
+        mock_response.raise_for_status = MagicMock()
+        mock_requests_get.return_value = mock_response
 
-        result = load_game_data_by_date(date_str)
-
-        mock_file_open.assert_called_once_with(expected_filepath, 'r', encoding='utf-8')
-        mock_json_load.assert_called_once() # With the file handle from mock_open
-        self.assertEqual(result, self.MOCK_JSON_DATA)
-        mock_pgfu.assert_not_called()
-
-    @patch('bracket_city_mcp.puzzle_loader.parse_game_from_url')
-    @patch('builtins.open', side_effect=FileNotFoundError("File not found mock"))
-    def test_lgdbd_file_not_found_falls_back_to_url_success(self, mock_file_open, mock_pgfu):
-        mock_pgfu.return_value = self.MOCK_URL_DATA
-        date_str = "2023-01-16"
-        expected_filepath = "games/json/20230116.json"
-        expected_url = f"https://ladypuzzle.pro/bracket-city-hints-answers-solution/{date_str}"
-
+        date_str = "2025-03-15" # Valid date within range
+        expected_url = f"https://raw.githubusercontent.com/aplassard/bracket-city-mcp/refs/heads/add-game-history/games/json/{date_str}.json"
 
         result = load_game_data_by_date(date_str)
 
-        mock_file_open.assert_called_once_with(expected_filepath, 'r', encoding='utf-8')
-        mock_pgfu.assert_called_once_with(expected_url)
-        self.assertEqual(result, self.MOCK_URL_DATA)
+        mock_requests_get.assert_called_once_with(expected_url, timeout=10)
+        mock_response.raise_for_status.assert_called_once()
+        mock_response.json.assert_called_once()
+        self.assertEqual(result, self.MOCK_SUCCESS_DATA)
 
-    @patch('bracket_city_mcp.puzzle_loader.parse_game_from_url')
-    @patch('builtins.open', side_effect=FileNotFoundError("File not found mock"))
-    def test_lgdbd_file_not_found_url_fetch_fails(self, mock_file_open, mock_pgfu):
-        mock_pgfu.return_value = {"error": "url fetch failed"}
-        date_str = "2023-01-17"
-        expected_filepath = "games/json/20230117.json"
-        expected_url = f"https://ladypuzzle.pro/bracket-city-hints-answers-solution/{date_str}"
+    def test_load_date_too_early(self):
+        date_str = "2024-12-31"
+        result = load_game_data_by_date(date_str)
+        self.assertEqual(result, {"error": "Date is outside the valid range (2025-01-01 to 2025-06-16)."})
+
+    def test_load_date_too_late(self):
+        date_str = "2025-06-17"
+        result = load_game_data_by_date(date_str)
+        self.assertEqual(result, {"error": "Date is outside the valid range (2025-01-01 to 2025-06-16)."})
+
+    def test_load_invalid_date_format(self):
+        date_str = "invalid-date-format"
+        result = load_game_data_by_date(date_str)
+        self.assertEqual(result, {"error": "Invalid date format. Expected YYYY-MM-DD."})
+
+    def test_load_invalid_date_format_month_day_swapped(self):
+        date_str = "2025-15-03" # Invalid month
+        result = load_game_data_by_date(date_str)
+        self.assertEqual(result, {"error": "Invalid date format. Expected YYYY-MM-DD."})
+
+    @patch('bracket_city_mcp.puzzle_loader.requests.get')
+    def test_load_network_error(self, mock_requests_get):
+        date_str = "2025-02-20" # Valid date
+        expected_url = f"https://raw.githubusercontent.com/aplassard/bracket-city-mcp/refs/heads/add-game-history/games/json/{date_str}.json"
+
+        # Configure the mock to raise RequestException
+        mock_requests_get.side_effect = requests.exceptions.RequestException("Simulated network failure")
 
         result = load_game_data_by_date(date_str)
 
-        mock_file_open.assert_called_once_with(expected_filepath, 'r', encoding='utf-8')
-        mock_pgfu.assert_called_once_with(expected_url)
-        self.assertEqual(result, {"error": "url fetch failed"})
-
-    @patch('bracket_city_mcp.puzzle_loader.parse_game_from_url')
-    @patch('bracket_city_mcp.puzzle_loader.json.load', side_effect=json.JSONDecodeError("Decode error", "doc", 0))
-    @patch('builtins.open', new_callable=mock_open, read_data="invalid json")
-    def test_lgdbd_json_decode_error(self, mock_file_open, mock_json_load, mock_pgfu):
-        date_str = "2023-01-18"
-        expected_filepath = "games/json/20230118.json"
-
-        result = load_game_data_by_date(date_str)
-
-        mock_file_open.assert_called_once_with(expected_filepath, 'r', encoding='utf-8')
-        mock_json_load.assert_called_once()
+        mock_requests_get.assert_called_once_with(expected_url, timeout=10)
         self.assertIn("error", result)
-        self.assertTrue(result["error"].startswith(f"Error decoding JSON from {expected_filepath}"))
-        mock_pgfu.assert_not_called()
+        self.assertTrue(result["error"].startswith(f"Failed to fetch game data from URL: {expected_url}"))
+        self.assertIn("Simulated network failure", result["error"])
 
-    @patch('bracket_city_mcp.puzzle_loader.parse_game_from_url')
-    @patch('builtins.open', side_effect=IOError("Disk read error")) # Generic IOError
-    def test_lgdbd_other_io_error(self, mock_file_open, mock_pgfu):
-        date_str = "2023-01-19"
-        expected_filepath = "games/json/20230119.json"
+    @patch('bracket_city_mcp.puzzle_loader.requests.get')
+    def test_load_http_error(self, mock_requests_get):
+        date_str = "2025-03-10" # Valid date
+        expected_url = f"https://raw.githubusercontent.com/aplassard/bracket-city-mcp/refs/heads/add-game-history/games/json/{date_str}.json"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        # Configure raise_for_status to simulate an HTTPError
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("404 Client Error: Not Found for url")
+        mock_requests_get.return_value = mock_response
 
         result = load_game_data_by_date(date_str)
 
-        mock_file_open.assert_called_once_with(expected_filepath, 'r', encoding='utf-8')
+        mock_requests_get.assert_called_once_with(expected_url, timeout=10)
+        mock_response.raise_for_status.assert_called_once()
         self.assertIn("error", result)
-        self.assertTrue(result["error"].startswith(f"IOError reading file {expected_filepath}"))
-        mock_pgfu.assert_not_called()
+        self.assertTrue(result["error"].startswith(f"Failed to fetch game data from URL: {expected_url}"))
+        self.assertIn("404 Client Error", result["error"])
+
+
+    @patch('bracket_city_mcp.puzzle_loader.requests.get')
+    def test_load_json_decode_error(self, mock_requests_get):
+        date_str = "2025-04-01" # Valid date
+        expected_url = f"https://raw.githubusercontent.com/aplassard/bracket-city-mcp/refs/heads/add-game-history/games/json/{date_str}.json"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        # Configure json() method to raise JSONDecodeError
+        mock_response.json.side_effect = json.JSONDecodeError("Expecting value", "document text", 0)
+        mock_requests_get.return_value = mock_response
+
+        result = load_game_data_by_date(date_str)
+
+        mock_requests_get.assert_called_once_with(expected_url, timeout=10)
+        mock_response.raise_for_status.assert_called_once()
+        mock_response.json.assert_called_once()
+        self.assertIn("error", result)
+        self.assertTrue(result["error"].startswith(f"Error decoding JSON from {expected_url}"))
+        self.assertIn("Expecting value", result["error"])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- I modified `puzzle_loader.load_game_data_by_date` to fetch game JSON directly from the specified GitHub raw URL.
- I implemented date validation to ensure game requests are within the 2025-01-01 to 2025-06-16 range.
- I removed HTML parsing logic (`generate_puzzle_structure`, `parse_game_from_url`) as it's no longer needed.
- I updated tests in `test_puzzle_loader.py` to reflect these changes, including tests for date validation, URL fetching, and error handling.
- I verified that `Game` class remains compatible by ensuring `test_game.py` tests pass.